### PR TITLE
Add ability to specify custom parser

### DIFF
--- a/src/rdflib_endpoint/sparql_endpoint.py
+++ b/src/rdflib_endpoint/sparql_endpoint.py
@@ -14,6 +14,7 @@ from rdflib.plugins.sparql import prepareQuery
 from rdflib.plugins.sparql.evaluate import evalPart
 from rdflib.plugins.sparql.evalutils import _eval
 from rdflib.plugins.sparql.parserutils import CompValue
+from rdflib.plugins.sparql.query import Processor
 from rdflib.plugins.sparql.sparql import QueryContext, SPARQLError
 
 
@@ -29,6 +30,7 @@ class SparqlEndpoint(FastAPI):
         description: str = "A SPARQL endpoint to serve machine learning models, or any other logic implemented in Python. \n[Source code](https://github.com/vemonet/rdflib-endpoint)",
         version: str = "0.1.0",
         graph: Union[Graph, ConjunctiveGraph, Dataset] = ConjunctiveGraph(),
+        processor: Union[str, Processor] = "sparql",,
         functions: Dict[str, Callable[..., Any]] = {},
         custom_eval: Optional[Callable[..., Any]] = None,
         enable_update: bool = False,
@@ -46,6 +48,7 @@ SELECT ?concat ?concatLength WHERE {
         FastAPI calls are defined in this constructor
         """
         self.graph = graph
+        self.processor = processor
         self.functions = functions
         self.title = title
         self.description = description
@@ -206,7 +209,7 @@ SELECT ?concat ?concatLength WHERE {
 
             try:
                 # query_results = self.graph.query(query, initNs=graph_ns)
-                query_results = self.graph.query(query)
+                query_results = self.graph.query(query, processor=self.processor)
             except Exception as e:
                 logging.error("Error executing the SPARQL query on the RDFLib Graph: " + str(e))
                 return JSONResponse(

--- a/src/rdflib_endpoint/sparql_endpoint.py
+++ b/src/rdflib_endpoint/sparql_endpoint.py
@@ -30,7 +30,7 @@ class SparqlEndpoint(FastAPI):
         description: str = "A SPARQL endpoint to serve machine learning models, or any other logic implemented in Python. \n[Source code](https://github.com/vemonet/rdflib-endpoint)",
         version: str = "0.1.0",
         graph: Union[Graph, ConjunctiveGraph, Dataset] = ConjunctiveGraph(),
-        processor: Union[str, Processor] = "sparql",,
+        processor: Union[str, Processor] = "sparql",
         functions: Dict[str, Callable[..., Any]] = {},
         custom_eval: Optional[Callable[..., Any]] = None,
         enable_update: bool = False,


### PR DESCRIPTION
This will allow for hacking in a custom SPARQL processor, that e.g., rewrites some nodes as we demonstrated in https://github.com/cthoyt/curies/pull/41