### PR TITLE
Reduce conditionals with a dictionary

### DIFF
--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -328,6 +328,7 @@ class SparqlRouter(APIRouter):
     def get_service_graph(self) -> rdflib.Graph:
         # Service description returned when no query provided
         service_description_ttl = SERVICE_DESCRIPTION_TTL_FMT.format(
+            public_url=self.public_url,
             title=self.title,
             description=self.description.replace("\n", ""),
         )

--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -86,11 +86,6 @@ api_responses: Optional[Dict[Union[int, str], Dict[str, Any]]] = {
     },
 }
 
-mimetype = {
-    "turtle": "text/turtle",
-    "xml_results": "application/sparql-results+xml",
-}
-
 #: This is default for federated queries
 DEFAULT_CONTENT_TYPE = "application/xml"
 
@@ -108,6 +103,8 @@ CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/sparql11-results-csv-tsv/
     "application/sparql-results+csv": "csv",
     "text/csv": "csv",  # for compatibility
+    # Extras
+    "text/turtle": "ttl",
 }
 
 
@@ -181,14 +178,14 @@ class SparqlRouter(APIRouter):
             if not query:
                 if str(request.headers["accept"]).startswith("text/html"):
                     return self.serve_yasgui()
-                # If not asking HTML returns the SPARQL endpoint service description
+                # If not asking HTML, return the SPARQL endpoint service description
                 service_graph = self.get_service_graph()
 
                 # Return the service description RDF as turtle or XML
-                if request.headers["accept"] == mimetype["turtle"]:
+                if request.headers["accept"] == "text/turtle":
                     return Response(
                         service_graph.serialize(format="turtle"),
-                        media_type=mimetype["turtle"],
+                        media_type="text/turtle",
                     )
                 else:
                     return Response(
@@ -238,7 +235,7 @@ class SparqlRouter(APIRouter):
 
             # Handle mime type for construct queries
             if query_operation == "Construct Query" and output_mime_type in {"application/json", "text/csv"}:
-                output_mime_type = mimetype["turtle"]
+                output_mime_type = "text/turtle"
                 # TODO: support JSON-LD for construct query?
                 # g.serialize(format='json-ld', indent=4)
             if query_operation == "Construct Query" and output_mime_type == "application/xml":

--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -233,13 +233,21 @@ class SparqlRouter(APIRouter):
             # Format and return results depending on Accept mime type in request header
             output_mime_type = request.headers.get("accept") or DEFAULT_CONTENT_TYPE
 
+            # Handle cases that are more complicated, like it includes multiple
+            # types, extra information, etc.
+            if output_mime_type not in CONTENT_TYPE_TO_RDFLIB_FORMAT:
+                output_mime_type = DEFAULT_CONTENT_TYPE
+
             # Handle mime type for construct queries
-            if query_operation == "Construct Query" and output_mime_type in {"application/json", "text/csv"}:
-                output_mime_type = "text/turtle"
-                # TODO: support JSON-LD for construct query?
-                # g.serialize(format='json-ld', indent=4)
-            if query_operation == "Construct Query" and output_mime_type == "application/xml":
-                output_mime_type = "application/rdf+xml"
+            if query_operation == "Construct Query":
+                if output_mime_type in {"application/json", "text/csv"}:
+                    output_mime_type = "text/turtle"
+                    # TODO: support JSON-LD for construct query?
+                    # g.serialize(format='json-ld', indent=4)
+                elif output_mime_type == "application/xml":
+                    output_mime_type = "application/rdf+xml"
+                else:
+                    pass  # TODO what happens here?
 
             try:
                 rdflib_format = CONTENT_TYPE_TO_RDFLIB_FORMAT[output_mime_type]


### PR DESCRIPTION
This PR reduces the need for several conditions by creating a dictionary mapping from mimetypes to the RDFLib output serialization key

I'm a bit worried that there were some implicit assumptions about what happens when mimetypes aren't simple that need to be addressed