### PR TITLE
Added support for multiple options in accept header

### DIFF
--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -144,9 +144,7 @@ def parse_accept_header(accept:str) -> list:
         # preserve order of appearance in the list
         dpref = dpref - 0.01
         preferences.append((parts[0], pref))
-    print(preferences)
     preferences.sort(key=lambda x: -x[1])
-    print(preferences)
     return [pref[0] for pref in preferences]
 
 class SparqlRouter(APIRouter):

--- a/tests/test_parse_accept.py
+++ b/tests/test_parse_accept.py
@@ -1,0 +1,19 @@
+import pytest
+import rdflib_endpoint.sparql_router
+
+accept_cases = [
+    ("text/xml", "text/xml"),
+    ("text/rdf+xml, text/xml, */*", "text/rdf+xml"),
+    ("text/html, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8", "text/html"),
+    ("text/html;q=0.3, application/xhtml+xml, application/xml;q=0.9, */*;q=0.8", "application/xhtml+xml"),
+    (
+        'text/turtle;q=0.9;profile="urn:example:profile-1", text/turtle;q=0.7;profile="urn:example:profile-2"',
+        "text/turtle",
+    ),
+]
+
+
+@pytest.mark.parametrize("accept,expected", accept_cases)
+def test_accept_preference(accept, expected):
+    pref = rdflib_endpoint.sparql_router.parse_accept_header(accept)
+    assert pref[0] == expected


### PR DESCRIPTION
Adds a bit of support for multiple options in the request Accept header, for example:
```
accept: application/x-ag-binary-rdf, application/sparql-results+json
```
The media types are checked in order of preference for a matching RDFLib format, falling back to`DEFAULT_CONTENT_TYPE`. 