### PR TITLE
Fix content type

### DIFF
--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -20,7 +20,7 @@ from rdflib.query import Processor
 from rdflib_endpoint.utils import (
     API_RESPONSES,
     FORMATS,
-    GENERAL_CONTENT_TYPE_TO_RDFLIB_FORMAT,
+    GENERIC_CONTENT_TYPE_TO_RDFLIB_FORMAT,
     GRAPH_CONTENT_TYPE_TO_RDFLIB_FORMAT,
     SD,
     SPARQL_RESULT_CONTENT_TYPE_TO_RDFLIB_FORMAT,
@@ -141,12 +141,12 @@ class SparqlRouter(APIRouter):
                     if query_operation == "Construct Query":
                         content_type_to_rdflib_format = {
                             **GRAPH_CONTENT_TYPE_TO_RDFLIB_FORMAT,
-                            **GENERAL_CONTENT_TYPE_TO_RDFLIB_FORMAT,
+                            **GENERIC_CONTENT_TYPE_TO_RDFLIB_FORMAT,
                         }
                     else:
                         content_type_to_rdflib_format = {
                             **SPARQL_RESULT_CONTENT_TYPE_TO_RDFLIB_FORMAT,
-                            **GENERAL_CONTENT_TYPE_TO_RDFLIB_FORMAT,
+                            **GENERIC_CONTENT_TYPE_TO_RDFLIB_FORMAT,
                         }
 
                     # Handle cases that are more complicated, like it includes multiple

--- a/src/rdflib_endpoint/sparql_router.py
+++ b/src/rdflib_endpoint/sparql_router.py
@@ -158,14 +158,24 @@ class SparqlRouter(APIRouter):
                             # Use the first mime_type that matches
                             break
 
-                    # Handle mime type for construct queries
-                    if query_operation == "Construct Query":
+                    # Convert generic mime types to specific ones
+                    if query_operation == "Construct Query" or query_operation == "Describe Query":
                         if output_mime_type == "text/csv":
                             output_mime_type = "text/turtle"
                         elif output_mime_type == "application/json":
                             output_mime_type = "application/ld+json"
                         elif output_mime_type == "application/xml":
                             output_mime_type = "application/rdf+xml"
+                        else:
+                            pass
+
+                    if query_operation == "Select Query" or query_operation == "Ask Query":
+                        if output_mime_type == "text/csv":
+                            output_mime_type = "application/sparql-results+csv"
+                        elif output_mime_type == "application/json":
+                            output_mime_type = "application/sparql-results+json"
+                        elif output_mime_type == "application/xml":
+                            output_mime_type = "application/sparql-results+xml"
                         else:
                             pass
 

--- a/src/rdflib_endpoint/utils.py
+++ b/src/rdflib_endpoint/utils.py
@@ -71,20 +71,11 @@ API_RESPONSES: Optional[Dict[Union[int, str], Dict[str, Any]]] = {
 
 #: A mapping from content types to the keys used for serializing
 #: in :meth:`rdflib.Graph.serialize` and other serialization functions
-CONTENT_TYPE_TO_RDFLIB_FORMAT = {
-    # https://www.w3.org/TR/sparql11-results-json/
-    "application/sparql-results+json": "json",
-    "application/json": "json",
-    "text/json": "json",
+GRAPH_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/rdf-sparql-XMLres/
-    "application/sparql-results+xml": "xml",
-    "application/xml": "xml",  # for compatibility
     "application/rdf+xml": "xml",  # for compatibility
-    "text/xml": "xml",  # not standard
     "application/ld+json": "json-ld",
     # https://www.w3.org/TR/sparql11-results-csv-tsv/
-    "application/sparql-results+csv": "csv",
-    "text/csv": "csv",  # for compatibility
     # Extras
     "text/turtle": "ttl",
     "text/n3": "n3",
@@ -93,6 +84,26 @@ CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     "application/trig": "trig",
     "application/trix": "trix",
     "application/n-quads": "nquads",
+}
+
+SPARQL_RESULT_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
+    # https://www.w3.org/TR/sparql11-results-json/
+    "application/sparql-results+json": "json",
+    # https://www.w3.org/TR/rdf-sparql-XMLres/
+    "application/sparql-results+xml": "xml",
+    # https://www.w3.org/TR/sparql11-results-csv-tsv/
+    "application/sparql-results+csv": "csv",
+}
+
+GENERAL_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
+    # https://www.w3.org/TR/sparql11-results-json/
+    "application/json": "json",
+    "text/json": "json",
+    # https://www.w3.org/TR/rdf-sparql-XMLres/
+    "application/xml": "xml",  # for compatibility
+    "text/xml": "xml",  # not standard
+    # https://www.w3.org/TR/sparql11-results-csv-tsv/
+    "text/csv": "csv",  # for compatibility
 }
 
 

--- a/src/rdflib_endpoint/utils.py
+++ b/src/rdflib_endpoint/utils.py
@@ -95,7 +95,7 @@ SPARQL_RESULT_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     "application/sparql-results+csv": "csv",
 }
 
-GENERAL_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
+GENERIC_CONTENT_TYPE_TO_RDFLIB_FORMAT = {
     # https://www.w3.org/TR/sparql11-results-json/
     "application/json": "json",
     "text/json": "json",

--- a/tests/test_oxrdflib.py
+++ b/tests/test_oxrdflib.py
@@ -48,9 +48,10 @@ def test_select_csv():
     # assert response.json()['results']['bindings'][0]['concat']['value'] == "Firstlast"
 
 
-def test_fail_select_turtle():
+def test_select_turtle():
     response = endpoint.post("/", data={"query": label_select}, headers={"accept": "text/turtle"})
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/sparql-results+xml"
     # assert response.json()['results']['bindings'][0]['concat']['value'] == "Firstlast"
 
 

--- a/tests/test_rdflib_endpoint.py
+++ b/tests/test_rdflib_endpoint.py
@@ -145,9 +145,10 @@ def test_multiple_accept_return_json2():
     assert response.json()["results"]["bindings"][0]["concat"]["value"] == "Firstlast"
 
 
-def test_fail_select_turtle():
+def test_select_turtle():
     response = endpoint.post("/", data={"query": concat_select}, headers={"accept": "text/turtle"})
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/sparql-results+xml"
 
 
 def test_concat_construct_turtle():

--- a/tests/test_rdflib_endpoint.py
+++ b/tests/test_rdflib_endpoint.py
@@ -191,6 +191,18 @@ def test_concat_construct_xml():
     assert response.text.startswith("<?xml ")
 
 
+def test_concat_construct_rdf_xml_with_two_accept_options():
+    response = endpoint.post(
+        "/",
+        data={"query": custom_concat_construct},
+        headers={"accept": "application/sparql-results+xml, application/rdf+xml"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/rdf+xml"
+    assert response.text.startswith("<?xml ")
+    assert "<rdf:RDF" in response.text
+
+
 def test_yasgui():
     # expected to return turtle
     response = endpoint.get(


### PR DESCRIPTION
When I query the endpoint with a CONSTRUCT query on a rdflib SPARQLStore it provides two accept headers:

`"application/sparql-results+xml, application/rdf+xml"`

In the current implementation `application/sparql-results+xml` is matched and returned as content-type, while the graph result actually is rendered as `application/rdf+xml`.

With the fix, sparql result types and graph serialization types are distinguished.

A test, that failed first and passes now is provided.