### PR TITLE
Add support for COTTAS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ If you want to use [oxigraph](https://github.com/oxigraph/oxigraph) as backend t
 pip install "rdflib-endpoint[cli,oxigraph]"
 ```
 
+If you want to serve [COTTAS files](https://doi.org/10.1007/978-3-032-09530-5_18) you can install with the optional dependency `cottas`:
+
+```bash
+pip install "rdflib-endpoint[cottas]"
+```
+
 > [!WARNING]
 > Oxigraph and `oxrdflib` do not support custom functions, so it can be only used to deploy graphs without custom functions.
 
@@ -77,6 +83,12 @@ You can use wildcard and provide multiple files, for example to serve all turtle
 
 ```bash
 rdflib-endpoint serve *.ttl *.jsonld *.nq
+```
+
+To serve all COTTAS files in the current folder you could run:
+
+```bash
+rdflib-endpoint serve *.cottas
 ```
 
 > Then access the YASGUI SPARQL editor on http://localhost:8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ web = [
 oxigraph = [
     "oxrdflib",
 ]
+cottas = [
+    "pycottas",
+]
 
 
 [dependency-groups]
@@ -89,6 +92,7 @@ features = [
     "cli",
     "web",
     "oxigraph",
+    "cottas",
 ]
 post-install-commands = [
     "pre-commit install",

--- a/src/rdflib_endpoint/__main__.py
+++ b/src/rdflib_endpoint/__main__.py
@@ -4,9 +4,10 @@ from typing import List
 
 import click
 import uvicorn
-from rdflib import Dataset
+from rdflib import Dataset, Graph
 
 from rdflib_endpoint import SparqlEndpoint
+from pycottas import COTTASStore
 
 
 @click.group()
@@ -28,17 +29,22 @@ def run_serve(files: List[str], host: str, port: int, store: str = "default", en
     if store == "oxigraph":
         store = store.capitalize()
     g = Dataset(store=store, default_union=True)
-    for glob_file in files:
-        file_list = glob.glob(glob_file)
-        for file in file_list:
-            g.parse(file)
-            click.echo(
-                click.style("INFO", fg="green")
-                + ":     📥️ Loaded triples from "
-                + click.style(str(file), bold=True)
-                + ", for a total of "
-                + click.style(str(len(g)), bold=True)
-            )
+
+    if len(files) == 1 and files[0].lower().endswith(".cottas"):
+        g = Graph(store=COTTASStore(files[0]))
+        click.echo(click.style("INFO", fg="green") + f": 📦 Mapped triples from {files[0]}.")
+    else:
+        for glob_file in files:
+            file_list = glob.glob(glob_file)
+            for file in file_list:
+                g.parse(file)
+                click.echo(
+                    click.style("INFO", fg="green")
+                    + ":     📥️ Loaded triples from "
+                    + click.style(str(file), bold=True)
+                    + ", for a total of "
+                    + click.style(str(len(g)), bold=True)
+                )
 
     app = SparqlEndpoint(
         graph=g,


### PR DESCRIPTION
This PR adds support for [COTTAS files](https://sferrada.com/publication/2025-iswc-arenas-guerrero-cottas/2025-iswc-arenas-guerrero-cottas.pdf). The COTTAS formats is a binary compression format for RDF files that allows for efficient querying without full decompression.

It uses the [pycottas](https://github.com/arenas-guerrero-julian/pycottas-endpoint) library and queries COTTAS files directly from disk without loading them to memory.